### PR TITLE
Update dependencies to Dropwizard 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,9 @@
     <project.name>${project.groupId}.${project.artifactId}</project.name>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <version.dropwizard>0.8.2</version.dropwizard>
-    <version.httpcomponents>4.3</version.httpcomponents>
-    <version.jackson-data-format-yaml>2.7.3</version.jackson-data-format-yaml>
+    <version.dropwizard>1.0.5</version.dropwizard>
+    <version.httpcomponents>4.5.2</version.httpcomponents>
+    <version.jackson-data-format-yaml>2.8.6</version.jackson-data-format-yaml>
     <version.junit>4.11</version.junit>
     <version.mockito>1.9.5</version.mockito>
   </properties>

--- a/src/main/java/com/thenewentity/utils/dropwizard/MultipleConfigurationMerger.java
+++ b/src/main/java/com/thenewentity/utils/dropwizard/MultipleConfigurationMerger.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.fasterxml.jackson.dataformat.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.Yaml;
 
 public class MultipleConfigurationMerger {
 


### PR DESCRIPTION
Updating dependencies to match the current Dropwizard release (1.0.5).